### PR TITLE
Fix cacheKeyForTree

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,12 +2,23 @@
 'use strict';
 
 var emberRollup = require('ember-rollup');
-var cacheKeyForStableTree = require('calculate-cache-key-for-tree').cacheKeyForStableTree;
+var caclculateCacheKeyForTree = require('calculate-cache-key-for-tree');
 
 module.exports = emberRollup([{
   name: 'spaniel',
   namespaced: false
 }], {
   name: 'ember-spaniel',
-  cacheKeyForTree: cacheKeyForStableTree
+
+  // ember-rollup implements a custom treeForVendor hook, we restore the caching
+  // for that hook here
+  cacheKeyForTree: function(treeType) {
+    if (treeType === 'vendor') {
+      // The treeForVendor returns a different value based on whether or not
+      // this addon is a nested dependency
+      return caclculateCacheKeyForTree(treeType, this, [!this.parent.parent]);
+    } else {
+      return this._super.cacheKeyForTree.call(this, treeType);
+    }
+  }
 });


### PR DESCRIPTION
The previous PR for this worked so long as you didn't have ember-spaniel at multiple levels in your project structure. This PR protects against that scenario.