### PR TITLE
[Fixes #9] Fix Zalgo

### DIFF
--- a/addon/spaniel-engines/ember-spaniel-engine.js
+++ b/addon/spaniel-engines/ember-spaniel-engine.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-const rAF = (typeof window === 'object') && typeof window.requestAnimationFrame === 'function' ? window.requestAnimationFrame : (callback) => callback();
+const rAF = (typeof window === 'object') && typeof window.requestAnimationFrame === 'function' ? window.requestAnimationFrame : (callback) => setTimeout(callback);
 
 export default {
   reads: [],


### PR DESCRIPTION
Ensure scheduled callbacks are never invoked synchronously.

Prior to this PR:

In environments with `window`

```js
let x = 0
scheduleWork(() => x++);
x++;
// x === 1;
```

In environments without `window`.

```js
let x = 0
scheduleWork(() => x++);
x++;
// x === 2;
```

WIth this PR, we always get:

```js
let x = 0
scheduleWork(() => x++);
x++;
// x === 1;
```