### PR TITLE
Add functions to flush the read and work queue

### DIFF
--- a/addon/spaniel-engines/ember-spaniel-engine.js
+++ b/addon/spaniel-engines/ember-spaniel-engine.js
@@ -36,14 +36,14 @@ export default {
       });
     }
   },
-  flushReadQueue() {
+  resetReadQueue() {
     this.reads = [];
   },
-  flushWorkQueue() {
+  resetWorkQueue() {
     this.work = [];
   },
-  flushAll() {
-    this.flushReadQueue();
-    this.flushWorkQueue();
+  resetAll() {
+    this.resetReadQueue();
+    this.resetWorkQueue();
   }
 };

--- a/addon/spaniel-engines/ember-spaniel-engine.js
+++ b/addon/spaniel-engines/ember-spaniel-engine.js
@@ -1,5 +1,9 @@
-import Ember from 'ember';
-const rAF = (typeof window === 'object') && typeof window.requestAnimationFrame === 'function' ? window.requestAnimationFrame : (callback) => setTimeout(callback);
+import Ember from "ember";
+const rAF =
+  typeof window === "object" &&
+  typeof window.requestAnimationFrame === "function"
+    ? window.requestAnimationFrame
+    : callback => setTimeout(callback);
 
 export default {
   reads: [],
@@ -31,5 +35,15 @@ export default {
         });
       });
     }
+  },
+  flushReadQueue() {
+    this.reads = [];
+  },
+  flushWorkQueue() {
+    this.work = [];
+  },
+  flushAll() {
+    this.flushReadQueue();
+    this.flushWorkQueue();
   }
 };

--- a/addon/spaniel-engines/ember-spaniel-engine.js
+++ b/addon/spaniel-engines/ember-spaniel-engine.js
@@ -1,4 +1,5 @@
 import Ember from "ember";
+
 const rAF =
   typeof window === "object" &&
   typeof window.requestAnimationFrame === "function"
@@ -9,14 +10,17 @@ export default {
   reads: [],
   work: [],
   running: false,
+
   scheduleRead(callback) {
     this.reads.unshift(callback);
     this.run();
   },
+
   scheduleWork(callback) {
     this.work.unshift(callback);
     this.run();
   },
+
   run() {
     if (!this.running) {
       this.running = true;
@@ -36,12 +40,15 @@ export default {
       });
     }
   },
+
   resetReadQueue() {
     this.reads = [];
   },
+
   resetWorkQueue() {
     this.work = [];
   },
+
   resetAll() {
     this.resetReadQueue();
     this.resetWorkQueue();

--- a/tests/unit/ember-spaniel-engine/ember-spaniel-engine-test.js
+++ b/tests/unit/ember-spaniel-engine/ember-spaniel-engine-test.js
@@ -1,0 +1,57 @@
+import EmberSpanielEngine from "spaniel";
+import { module, test } from "qunit";
+
+const noopFn = () => {};
+
+module("Unit | ember-spaniel-engine", {
+  beforeEach() {
+    this.engine = EmberSpanielEngine.getGlobalEngine();
+  }
+});
+
+test("test scheduleRead and flushReadQueue", function(assert) {
+  this.engine.scheduleRead(noopFn);
+  assert.equal(
+    this.engine.reads.length,
+    1,
+    "It schedules a callback in the read queue"
+  );
+  this.engine.flushReadQueue();
+  assert.equal(
+    this.engine.reads.length,
+    0,
+    "It cancels all callbacks in the read queue"
+  );
+});
+
+test("test scheduleWork and flushWorkQueue", function(assert) {
+  this.engine.scheduleWork(noopFn);
+  assert.equal(
+    this.engine.work.length,
+    1,
+    "It schedules a callback in the work queue"
+  );
+  this.engine.flushWorkQueue();
+  assert.equal(
+    this.engine.work.length,
+    0,
+    "It cancels all callbacks in the work queue"
+  );
+});
+
+test("test flushAll", function(assert) {
+  this.engine.scheduleRead(noopFn);
+  this.engine.scheduleWork(noopFn);
+
+  this.engine.flushAll();
+  assert.equal(
+    this.engine.work.length,
+    0,
+    "It cancels all callbacks in the work queue"
+  );
+  assert.equal(
+    this.engine.reads.length,
+    0,
+    "It cancels all callbacks in the read queue"
+  );
+});

--- a/tests/unit/ember-spaniel-engine/ember-spaniel-engine-test.js
+++ b/tests/unit/ember-spaniel-engine/ember-spaniel-engine-test.js
@@ -9,14 +9,14 @@ module("Unit | ember-spaniel-engine", {
   }
 });
 
-test("test scheduleRead and flushReadQueue", function(assert) {
+test("test scheduleRead and resetReadQueue", function(assert) {
   this.engine.scheduleRead(noopFn);
   assert.equal(
     this.engine.reads.length,
     1,
     "It schedules a callback in the read queue"
   );
-  this.engine.flushReadQueue();
+  this.engine.resetReadQueue();
   assert.equal(
     this.engine.reads.length,
     0,
@@ -24,14 +24,14 @@ test("test scheduleRead and flushReadQueue", function(assert) {
   );
 });
 
-test("test scheduleWork and flushWorkQueue", function(assert) {
+test("test scheduleWork and resetWorkQueue", function(assert) {
   this.engine.scheduleWork(noopFn);
   assert.equal(
     this.engine.work.length,
     1,
     "It schedules a callback in the work queue"
   );
-  this.engine.flushWorkQueue();
+  this.engine.resetWorkQueue();
   assert.equal(
     this.engine.work.length,
     0,
@@ -39,11 +39,11 @@ test("test scheduleWork and flushWorkQueue", function(assert) {
   );
 });
 
-test("test flushAll", function(assert) {
+test("test resetAll", function(assert) {
   this.engine.scheduleRead(noopFn);
   this.engine.scheduleWork(noopFn);
 
-  this.engine.flushAll();
+  this.engine.resetAll();
   assert.equal(
     this.engine.work.length,
     0,


### PR DESCRIPTION
It will allow to force clear the queues preventing the memory leaks in case of early exits like test failure

[Issue#19](https://github.com/asakusuma/ember-spaniel/issues/19)