### PR TITLE
Add ability to configure Watcher options

### DIFF
--- a/addon/services/viewport.js
+++ b/addon/services/viewport.js
@@ -21,10 +21,10 @@ export default Ember.Service.extend({
     }, defaultRootMargin));
   },
 
-  getWatcher() {
-    return this._globalWatcher || (this._globalWatcher = new spaniel.Watcher({
+  getWatcher(options = {}) {
+    return this._globalWatcher || (this._globalWatcher = new spaniel.Watcher(Ember.merge({
       rootMargin: this.get('rootMargin')
-    }));
+    }, options)));
   },
 
   isInViewport(el, { ratio, rootMargin } = {}) {


### PR DESCRIPTION
Hey, thanks for this, I was looking for something to [replace `Waypoints`](https://github.com/travis-ci/travis-web/pull/1422) as a step toward removing all of `travis-web`’s Bower dependencies.

I wanted to be able to configure `Watcher` as [described in the Spaniel documentation](https://linkedin.github.io/spaniel/interfaces/watcherconfig.html), so I added this interface. It seems like there aren’t tests for this but if I missed them, let me know, or if anything needs fixing.