### PR TITLE
Bumping ember-rollup version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "",
   "dependencies": {
     "calculate-cache-key-for-tree": "^1.1.0",
-    "ember-rollup": "^1.0.1",
+    "ember-rollup": "^1.0.2",
     "ember-cli-babel": "^6.6.0",
     "spaniel": "2.4.4"
   },


### PR DESCRIPTION
Pre built directory was not being published to npm registery because the generated pre-built directory had a link. Fixed in ember-rollup https://github.com/asakusuma/ember-rollup/pull/24